### PR TITLE
Upgrade Node.js Version to 20.16.0 in GitHub Actions Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.17.0
+          node-version: 20.16.0
       - name: Install dependencies
         run: yarn install
       - name: Build project


### PR DESCRIPTION
This pull request updates the Node.js version used in our GitHub Actions workflow. The build-and-test job in the build.yml file has been modified to use Node.js version 20.16.0.

Changes include:
1. Updated the setup-node action in the build-and-test job to use Node.js version 20.16.0.

This upgrade ensures our project is built and tested against the latest stable version of Node.js, allowing us to leverage new features and improvements in the language, and ensuring our project remains up-to-date and secure.