### PR TITLE
Upgreading packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@babel/eslint-parser": "^7.25.1",
+    "@babel/eslint-parser": "^7.25.7",
     "@eslint/js": "^9.11.1",
     "@eslint/config-inspector": "^0.5.4",
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.0.1",
     "@testing-library/dom": "^10.4.0",
-    "@types/react": "^18.3.10",
+    "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.0",
     "babel-preset-jest": "^29.6.3",
     "eslint": "^9.11.1",
@@ -32,7 +32,7 @@
     "prop-types": "^15.8.1",
     "vite": "^5.4.8",
     "@vitejs/plugin-react-swc": "^3.7.1",
-    "vitest": "^2.1.1",
-    "@vitest/coverage-v8": "^2.1.1"
+    "vitest": "^2.1.2",
+    "@vitest/coverage-v8": "^2.1.2"
   }
 }


### PR DESCRIPTION
**Description**

This pull request includes the upgrades for dev dependencies. These upgrades are necessary to take advantage of the latest features, improvements, and bug fixes in these packages.

**Changes**

Upgraded @babel/eslint-parser to version 7.25.7.
Upgraded @types/react to version 18.3.11.
Upgraded vitest to version 2.1.2.
Upgraded @vitest/coverage-v8 to version 2.1.2.

**Impact**

This change should not impact the functionality of the application. It will, however, improve our testing and coverage reporting setup.