### PR TITLE
Upgrading eslint-plugin-jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "eslint": "^9.14.0",
-    "eslint-plugin-jest": "^28.8.3",
+    "eslint-plugin-jest": "^28.9.0",
     "prop-types": "^15.8.1",
     "vite": "^5.4.10",
     "@vitejs/plugin-react-swc": "^3.7.1",

--- a/package.json
+++ b/package.json
@@ -20,13 +20,11 @@
   "devDependencies": {
     "@babel/eslint-parser": "^7.25.9",
     "@eslint/js": "^9.14.0",
-    "@eslint/config-inspector": "^0.5.6",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",
     "@testing-library/dom": "^10.4.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
-    "babel-preset-jest": "^29.6.3",
     "eslint": "^9.14.0",
     "eslint-plugin-jest": "^28.8.3",
     "prop-types": "^15.8.1",


### PR DESCRIPTION
**Upgrading eslint-plugin-jest**

Upgrading eslint-plugin-jest to new minor version: 28.9.0.

**Removing Unused Dependencies**

- @eslint/config-inspector
- babel-preset-jest