### PR TITLE
Migrate to React 19.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,21 +14,21 @@
   },
   "dependencies": {
     "jsdom": "^25.0.1",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.25.9",
     "@eslint/js": "^9.17.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "^16.1.0",
     "@testing-library/dom": "^10.4.0",
-    "@types/react": "^18.3.12",
-    "@types/react-dom": "^18.3.1",
+    "@types/react": "^19.0.2",
+    "@types/react-dom": "^19.0.2",
     "eslint": "^9.17.0",
-    "eslint-plugin-jest": "^28.9.0",
+    "eslint-plugin-jest": "^28.10.0",
     "prop-types": "^15.8.1",
-    "vite": "^6.0.2",
+    "vite": "^6.0.5",
     "@vitejs/plugin-react-swc": "^3.7.2",
     "vitest": "^2.1.8",
     "@vitest/coverage-v8": "^2.1.8"


### PR DESCRIPTION
**Migrating to React 19

- React to 19.0.0
- Supporting react types upgraded
- Vite and eslint upgrades